### PR TITLE
The version number on WebUI includes git sha such as 0.1.0-26-1-gd529…

### DIFF
--- a/ognbase/Web.cpp
+++ b/ognbase/Web.cpp
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "git-version.h"
 #include "WiFi.h"
 #include "ESPAsyncWebServer.h"
 #include "SPIFFS.h"
@@ -218,7 +219,7 @@ void Web_setup(ufo_t* this_aircraft)
 
     snprintf(offset, size, index_html,
              station_addr,
-             SOFTRF_FIRMWARE_VERSION,
+             GIT_VERSION,
              ogn_callsign,
              pos_lat,
              pos_lon,


### PR DESCRIPTION
…363.

You need to run the following commands.

cat <<EOF >make-git-version
#!/bin/bash

# Go to the source directory.
[ -n "\$1" ] && cd "$1" || exit 1

# Build a version string with git.
version=\$(git describe --tags --always --dirty 2> /dev/null)

# If this is not a git repository, fallback to the compilation date.
[ -n "\$version" ] || version=\$(date -I)

# Save this in git-version.h.
echo "#define GIT_VERSION \"\$version\"" > \$2/sketch/git-version.h
EOF
chmod +x make-git-version
sudo mv make-git-version /usr/local/bin/
echo recipe.hooks.sketch.prebuild.1.pattern=make-git-version "{build.source.path}" "{build.path}" >~/.arduino15/packages/esp32/hardware/esp32/1.0.6/platform.local.txt
touch software/firmware/source/SoftRF/git-version.h

By above commands, arduino runs /usr/local/bin/make-git-version on compile.
It creates /tmp/arduino_build_XXXXXX/sketch/git-version.h which has

define GIT_VERSION "0.1.0-26-1-gd529363"

for example.